### PR TITLE
fix: widget side panel support

### DIFF
--- a/app/index.ejs
+++ b/app/index.ejs
@@ -45,7 +45,7 @@
         kWidget.embed({
             "targetId": "kaltura_player_1631833648",
             "wid": "_2302901",
-            "uiconf_id": 49259063,
+            "uiconf_id": 43470041,
             "flashvars": {
                 "annoto": {
                     'plugin': true,

--- a/app/scripts/plugin/mw.ts
+++ b/app/scripts/plugin/mw.ts
@@ -64,6 +64,8 @@ interface Player extends Element {
 
     getWidth: () => number;
     getHeight: () => number;
+    getPlayerWidth: () => number;
+    getPlayerHeight: () => number;
     getPlayerElement: () => Element;
     getInterface: () => JQuery;
     getVideoHolder: () => JQuery;

--- a/app/scripts/plugin/player-adaptor.ts
+++ b/app/scripts/plugin/player-adaptor.ts
@@ -127,13 +127,18 @@ export class PlayerAdaptor implements IPlayerAdaptorApi {
     }
 
     public width() : number | string {
-        // return this.getProperty('{video.player.width}');
-        return this.player.getWidth();
+        const { player } = this;
+        
+        return player.getPlayerWidth();
     }
 
     public height() : number | string {
-        // return this.getProperty('{video.player.height}');
-        return this.player.getHeight();
+        const { player } = this;
+        const isPlaylist = $('.playlistInterface').length > 0;
+        if (isPlaylist) {
+            return $('.playlistInterface').height() || player.getHeight();
+        }
+        return player.getHeight();
     }
 
     public controlsHidden() : boolean {
@@ -159,7 +164,7 @@ export class PlayerAdaptor implements IPlayerAdaptorApi {
     }
 
     public embeddableElement() {
-        return $('.nnk-side-panel').get(0) || $('.mwPlayerContainer').get(0);
+        return $('.mwPlayerContainer').get(0);
     }
 
     public trackMarginLeft() : number | string {

--- a/app/styles/plugin.scss
+++ b/app/styles/plugin.scss
@@ -1,80 +1,37 @@
-$widgetWidth: 350px;
-$widgetFsWidth: 400px;
-$playlistWidth: 320px;
-$minibarWidth: 64px;
 
-.nnk-side-panel {
-    position: relative;
-    width: 100%;
-    height: 100%;
-    --nnk-side-panel-width: 350px;
-    --nnk-fs-side-panel-width: 400px;
-}
+.annoto-player-element.nn-side-panel {
+    .videoHolder,
+    .topBarContainer,
+    .controlBarContainer,
+    #loadingSpinner_kplayer {
+        transition: width ease-in-out 0.2s;
+        width: calc(100% - var(--nn-side-panel-width)) !important;
+        left: 0;
+    }
 
-@media only screen and (min-width: 590px) {
-    .nnk-side-panel {
-        &:not(.nnk-fullscreen):not(.nnk-hidden),
-        &.nnk-always-on:not(.nnk-hidden) {
-            .mwPlayerContainer {
-                float: left;
-                width: calc(100% - #{$widgetWidth});
-                width: calc(100% - var(--nnk-side-panel-width, #{$widgetWidth}));
-                transition: width ease-in-out .2s;
-                &.fullscreen {
-                    width: calc(100% - #{$widgetFsWidth}) !important;
-                    width: calc(100% - var(--nnk-fs-side-panel-width, #{$widgetFsWidth})) !important;
-                    position: relative !important;
-                }
-            }
-            &.nnk-left {
-                .mwPlayerContainer {
-                    float: right;
-                }
-            }
-        }
-
-        &:not(.nnk-hidden):not(.nnk-minimised) {
-            > #annoto-app { // apply only when not in full screen
-                .annoto-overlay {
-                    .annoto-widget-container > div.nn-color-background,
-                    .annoto-resizable {
-                            border-radius: 0;
-                    }
-                }
-            }
+    &:not(.nn-side-panel-left) {
+        .controlBar,
+        .playlistAPI {
+            transition: right ease-in-out 0.2s;
+            right: var(--nn-side-panel-width) !important;
         }
     }
-}
 
-@media only screen and (min-width: 1100px) {
-    .nnk-playlist-layout {
-        .playlistInterface {
-            .nnk-side-panel:not(.nnk-fullscreen) {
-                position: relative;
-                width: calc(100% - #{$playlistWidth}) !important;
-                float: left;
-                &:not(.nnk-fullscreen):not(.nnk-hidden),
-                &.nnk-always-on:not(.nnk-hidden) {
-                    .mwPlayerContainer {
-                        width: calc(100% - #{$widgetWidth}) !important;
-                        width: calc(100% - var(--nnk-side-panel-width, #{$widgetWidth})) !important;
-                    }
-                }
-                &.nnk-hidden {
-                    .mwPlayerContainer {
-                        width: calc(100% - #{$minibarWidth}) !important;
-                    }
-                }
-            }
-            .nnk-side-panel.nnk-left {
-                .mwPlayerContainer {
-                    float: right !important;
-                }
-            }
-
-            .playlistAPI.k-vertical {
-                width: $playlistWidth !important;
-            }
+    &.nn-side-panel-left {
+        .videoHolder,
+        .topBarContainer,
+        .controlBarContainer,
+        #loadingSpinner_kplayer {
+            left: auto !important;
+            right: 0 !important;
+            float: right !important;
+        }
+        .sideBarContainerReminder.left,
+        .sideBarContainer.left.openBtn {
+            left: var(--nn-side-panel-width) !important;
+        }
+        .sideBarContainerReminder.left.shifted {
+            left: calc(30% + var(--nn-side-panel-width)) !important;
         }
     }
 }


### PR DESCRIPTION
Remove wrap of player and make use of built in widget support
Solves many issues:
* A YouTube video with Annoto shows black screen when Annoto is in Side Panel mode
* Side panel ux for playlist
* There is no way to dismiss "More Videos" banner for Youtube videos