### PR TITLE
Timeupdate on the end of the video

### DIFF
--- a/app/scripts/plugin/player-adaptor.ts
+++ b/app/scripts/plugin/player-adaptor.ts
@@ -32,6 +32,7 @@ export class PlayerAdaptor implements IPlayerAdaptorApi {
     private captureUIDispose?: () => void;
     protected updatedEntry: MediaEtry;
     private onTimeUpdateCb?: PlayerEventCallback;
+    private timeUpdateOnSeekCalled = false;
 
     constructor(ctx: PluginCtx) {
         this.ctx = ctx;
@@ -50,6 +51,7 @@ export class PlayerAdaptor implements IPlayerAdaptorApi {
         this.events = [];
         this.onTimeUpdateCb = undefined;
         this.onMediaChangeCb = undefined;
+        this.timeUpdateOnSeekCalled = false;
         if (this.captureUIDispose) {
             this.captureUIDispose();
         }
@@ -197,7 +199,12 @@ export class PlayerAdaptor implements IPlayerAdaptorApi {
     public onSeek(cb: PlayerEventCallback) {
         this.on('seeked', () => {
             // When user seeks into the end of the video from paused state, the player will fire 'seeked' event, but not 'timeupdate'
-            setTimeout(() => this.timeUpdateHandle());
+            this.timeUpdateOnSeekCalled = false;
+            setTimeout(() => {
+                if (!this.timeUpdateOnSeekCalled) {
+                    this.timeUpdateHandle()
+                }
+            });
             this.callIfNotAd(cb)
         });
     }
@@ -270,6 +277,7 @@ export class PlayerAdaptor implements IPlayerAdaptorApi {
     }
 
     private timeUpdateHandle(): void {
+        this.timeUpdateOnSeekCalled = true;
         if (this.onTimeUpdateCb) {
             this.callIfNotAd(this.onTimeUpdateCb);
         }

--- a/app/scripts/plugin/player-adaptor.ts
+++ b/app/scripts/plugin/player-adaptor.ts
@@ -193,7 +193,7 @@ export class PlayerAdaptor implements IPlayerAdaptorApi {
     public onSeek(cb: PlayerEventCallback) {
         this.on('seeked', () => {
             if (this.onTimeUpdateCb) {
-                this.onTimeUpdateCb();
+                this.callIfNotAd(this.onTimeUpdateCb);
             }
             this.callIfNotAd(cb)
         });

--- a/app/scripts/plugin/player-adaptor.ts
+++ b/app/scripts/plugin/player-adaptor.ts
@@ -225,6 +225,14 @@ export class PlayerAdaptor implements IPlayerAdaptorApi {
         this.on('playerError', cb);
     }
 
+    public onVideoEnd(cb: PlayerEventCallback) {
+        this.on('seeked', () => {
+            if (this.getTimeProperty('{duration}') - this.getTimeProperty('{video.player.currentTime}') < 1) {
+                this.callIfNotAd(cb);
+            }
+        })
+    }
+
     public updateMediaEntry(entry?: MediaEtry | null) {
         if (entry || entry === null) {
             this.updatedEntry = entry;

--- a/app/scripts/plugin/player-adaptor.ts
+++ b/app/scripts/plugin/player-adaptor.ts
@@ -192,6 +192,8 @@ export class PlayerAdaptor implements IPlayerAdaptorApi {
 
     public onSeek(cb: PlayerEventCallback) {
         this.on('seeked', () => {
+            /* When user seeks into the end of the video from paused state,
+               the player will fire 'seeked' event, but not 'timeupdate'*/
             if (this.onTimeUpdateCb) {
                 this.callIfNotAd(this.onTimeUpdateCb);
             }


### PR DESCRIPTION
https://app.clickup.com/t/861mjv7ry
https://github.com/Annoto/annoto/pull/120

Problem is: when user seek from paused state to the end of the video, it will trigger seek event, but not timeupdate. 
It was a problem, but now we use lastProcessedTimestamp for this cases, so PR can be deleted.